### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Perl6/Parsing.pm
+++ b/lib/Perl6/Parsing.pm
@@ -3,7 +3,7 @@ use Perl6::Actions:from<NQP>;
 
 use QRegex:from<NQP>; 
 
-class Perl6::Parsing;
+unit class Perl6::Parsing;
 
 
 has Mu $.parser;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.